### PR TITLE
Fix link to Options page on NetHackWiki

### DIFF
--- a/web/nethackrc.default
+++ b/web/nethackrc.default
@@ -2,7 +2,7 @@
 # Clear everything (and reload the game) to restore to default
 # Will be applied after the game is reloaded (you can save & quit)
 
-# For more details, read http://nethack.wikia.com/wiki/Options
+# For more details, read http://nethackwiki.com/wiki/Options
 # Note that not all the NetHack options are supported by BrowserHack
 
 OPTIONS=cmdassist, hilite_pet, autopickup, autoquiver


### PR DESCRIPTION
According to the NetHack Wikia main page, `http://nethack.wikia.com/wiki/Main_Page`:

> Please note that this Wiki is no longer in use, and most users have moved to nethackwiki.com.

So I changed the link to the Options page on that domain, `http://nethackwiki.com/wiki/Options`
